### PR TITLE
Update HasActions.php

### DIFF
--- a/packages/tables/src/Table/Concerns/HasActions.php
+++ b/packages/tables/src/Table/Concerns/HasActions.php
@@ -58,7 +58,7 @@ trait HasActions
             $this->actions[] = $action;
         }
 
-        $this->actionsPosition($position);
+        $position && $this->actionsPosition($position);
 
         return $this;
     }


### PR DESCRIPTION
`$this->actionsPosition($position)`

is called even if `$position` is null, overriding any global setup that has (eventually) been made with (for example)

`Table::configureUsing(fn (Table $table)  => $table->actionsPosition(ActionsPosition::BeforeColumns)).`

This PR fixes it.